### PR TITLE
Implemented index hooks by utilizing the onChange callback.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+*.log
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # r-swipeable
+
 A react component making its child elements swipeable.
 
 - Snaps nearest child center to swipe-container center.
@@ -7,7 +8,8 @@ A react component making its child elements swipeable.
 ## Usage
 
 ### Swipe and drag
-```js
+
+```javascript
 import React, { Component, PropTypes } from 'react';
 import Swipeable from 'r-swipeable';
 
@@ -31,38 +33,47 @@ const SwipeableComponent = () => (
 );
 
 export default SwipeableComponent;
-
 ```
+
 #### Example
+
 ![example-gif](http://gropio.com/stek/file/d3gzts)
 
-### Swipe drag and button navigation
-```js
+### Add button navigation
+To manage the swiper state from a parent component us the following structure:
+
+```javascript
 class SwipeableComponent extends Component {
   constructor(props) {
     super(props);
 
-    this.setSwipeNode = this.setSwipeNode.bind(this);
+    this.onChange = this.onChange.bind(this);
     this.forward = this.step.bind(this, true);
     this.backward = this.step.bind(this, false);
   }
 
-  step(forwards) {
-    let currentIndex = this.swiper.state.currentCenteredChildIndex;
+  step(forward) {
+    let currentIndex = this.state.currentIndex;
 
-    forwards === true ?
-      this.swiper.positionViewByChildIndex(++currentIndex):
-      this.swiper.positionViewByChildIndex(--currentIndex);
+    if (forward) {
+      this.setState({ currentIndex: ++this.state.currentIndex });
+    } else {
+      this.setState({ currentIndex: --this.state.currentIndex });
+    }
   }
 
-  setSwipeNode(node) {
-    this.swiper = node;
+  onChange(index) {
+    // Container state if swiper is updated internally by a drag and keep indexes in sync.
+    this.setState({ currentIndex: index });
   }
 
   render() {
     return (
       <div>
-        <Swipeable ref={ this.setSwipeNode }>
+        <Swipeable
+          onChange={ this.onChange }
+          currentIndex={ this.state.currentIndex }
+        >
           { renderTestItems() }
         </Swipeable>
 
@@ -82,10 +93,13 @@ export default SwipeableComponent;
 ```
 
 ## API
+
 ### `<Swipeable>`
+
 Wrapper component which makes its child elements swipeable.
 
 #### Props
+
 `children` (required) - Elements that will be wrapper (in row).
 
 `flickSensitivity` - Limit which specifies when an actual flick gesture occurred.
@@ -95,11 +109,17 @@ Wrapper component which makes its child elements swipeable.
 `className` - String used to enhance or override style.
 
 #### Methods
-`positionViewByChildIndex(targetIndex)`
 
-Moves `targetIndex` index to viewport center.
-```js
-function goTo(index) {
-  swiper.positionViewByChildIndex(index):
+`onChange(index)`
+
+Last updated index.
+
+```javascript
+function cb(index) {
+  ...
 }
+
+<Swipeable onChange={ cb }>
+  ...
+</Swipeable>
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A react component making its child elements swipeable.
 - Child x-axis centers are currently based on the first child element.
 
 ## Usage
+
+### Swipe and drag
 ```js
 import React, { Component, PropTypes } from 'react';
 import Swipeable from 'r-swipeable';
@@ -31,5 +33,73 @@ const SwipeableComponent = () => (
 export default SwipeableComponent;
 
 ```
-## Example
+#### Example
 ![example-gif](http://gropio.com/stek/file/d3gzts)
+
+### Swipe drag and button navigation
+```js
+class SwipeableComponent extends Component {
+  constructor(props) {
+    super(props);
+
+    this.setSwipeNode = this.setSwipeNode.bind(this);
+    this.forward = this.step.bind(this, true);
+    this.backward = this.step.bind(this, false);
+  }
+
+  step(forwards) {
+    let currentIndex = this.swiper.state.currentCenteredChildIndex;
+
+    forwards === true ?
+      this.swiper.positionViewByChildIndex(++currentIndex):
+      this.swiper.positionViewByChildIndex(--currentIndex);
+  }
+
+  setSwipeNode(node) {
+    this.swiper = node;
+  }
+
+  render() {
+    return (
+      <div>
+        <Swipeable ref={ this.setSwipeNode }>
+          { renderTestItems() }
+        </Swipeable>
+
+        <div onClick={ this.forward }>
+          { `Go to forward` }
+        </div>
+
+        <div onClick={ this.backward }>
+          { `Go to backward` }
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SwipeableComponent;
+```
+
+## API
+### `<Swipeable>`
+Wrapper component which makes its child elements swipeable.
+
+#### Props
+`children` (required) - Elements that will be wrapper (in row).
+
+`flickSensitivity` - Limit which specifies when an actual flick gesture occurred.
+
+`slopeLimit` - Number indicating if a swipe should be considered x-drag or y-drag. It's only possible to swipe in on direction at the time.
+
+`className` - String used to enhance or override style.
+
+#### Methods
+`positionViewByChildIndex(targetIndex)`
+
+Moves `targetIndex` index to viewport center.
+```js
+function goTo(index) {
+  swiper.positionViewByChildIndex(index):
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # r-swipeable
 
-A react component making its child elements swipeable.
+r-swipeable provides `Swipeable` which makes its subcomponents horizontally swipeable.
 
-- Snaps nearest child center to swipe-container center.
-- Child x-axis centers are currently based on the first child element.
+* Repositions to nearest child center after a flick gesture.
+* Uses `requestAnimationFrame` to manage translations changes.
 
 ## Usage
 
@@ -14,16 +14,14 @@ import React, { Component, PropTypes } from 'react';
 import Swipeable from 'r-swipeable';
 
 function renderTestItems() {
-  return [1, 2, 3, 4, 5].map(i => {
-    return (
-      <div
-        className={`child child-${i}`}
-        key={ i }
-      >
-        { i }
-      </div>
-    );
-  });
+  return [1, 2, 3, 4, 5].map(i => (
+    <div
+      className={`child child-${i}`}
+      key={ i }
+    >
+      { i }
+    </div>
+  ));
 }
 
 const SwipeableComponent = () => (
@@ -63,7 +61,7 @@ class SwipeableComponent extends Component {
   }
 
   onChange(index) {
-    // Container state if swiper is updated internally by a drag and keep indexes in sync.
+    // Update container state if swipeable is updated internally by a drag.
     this.setState({ currentIndex: index });
   }
 
@@ -78,11 +76,11 @@ class SwipeableComponent extends Component {
         </Swipeable>
 
         <div onClick={ this.forward }>
-          { `Go to forward` }
+          { `Go to forwards` }
         </div>
 
         <div onClick={ this.backward }>
-          { `Go to backward` }
+          { `Go to backwards` }
         </div>
       </div>
     );
@@ -96,23 +94,19 @@ export default SwipeableComponent;
 
 ### `<Swipeable>`
 
-Wrapper component which makes its child elements swipeable.
-
 #### Props
 
-`children` (required) - Elements that will be wrapper (in row).
+`children` (required) - Elements that will be wrapper and made swipeable. (horizontally)
 
-`flickSensitivity` - Limit which specifies when an actual flick gesture occurred.
+`flickSensitivity` - Specifies a limit which decides when an actual flick gesture should be triggered.
 
-`slopeLimit` - Number indicating if a swipe should be considered x-drag or y-drag. It's only possible to swipe in on direction at the time.
-
-`className` - String used to enhance or override style.
+`slopeLimit` - Indicates if a swipe should be considered x-drag or y-drag. It's only possible to swipe in on direction at the time.
 
 #### Methods
 
-`onChange(index)`
+`onChange(callback)`
 
-Last updated index.
+Called with the new `index` as a parameter, every time a new index is set.
 
 ```javascript
 function cb(index) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git@github.com:JoelRoxell/r-swipeable.git"
   },
   "devDependencies": {
+    "babel": "^6.5.2",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
@@ -31,6 +32,7 @@
     "mocha": "^3.0.2",
     "react": "^15.3.1",
     "react-addons-test-utils": "^15.3.1",
+    "react-dom": "^15.3.1",
     "react-prefixer": "^1.1.4",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.15.1"

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -1,4 +1,3 @@
-
 import React, { Component, PropTypes } from 'react';
 import autoprefixer from 'react-prefixer';
 import styles from './style';
@@ -148,17 +147,17 @@ class Swipeable extends Component {
   /**
    * Position view by child index.
    */
-  positionViewByChildIndex(index) {
-    // Limit index bounds.
-    if (index < 0 ) {
-      index = 0;
-    } else if (index === this.childXCenterPosList.length) {
-      index = this.childXCenterPosList.length - 1;
+  positionViewByChildIndex(targetIndex) {
+    // Limit targetIndex bounds.
+    if (targetIndex < 0 ) {
+      targetIndex = 0;
+    } else if (targetIndex === this.childXCenterPosList.length) {
+      targetIndex = this.childXCenterPosList.length - 1;
     }
 
     this.setState({
-      contentPos: this.viewportCenter - this.childXCenterPosList[index].clientXCenter,
-      currentCenteredChildIndex: index
+      contentPos: this.viewportCenter - this.childXCenterPosList[targetIndex].clientXCenter,
+      currentCenteredChildIndex: targetIndex
     });
   }
 
@@ -350,7 +349,7 @@ class Swipeable extends Component {
 Swipeable.LEFT = 'LEFT';
 Swipeable.RIGHT = 'RIGHT';
 Swipeable.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element),
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
   className: PropTypes.string,
   flickSensitivity: PropTypes.number,
   slopeLimit: PropTypes.number

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -32,6 +32,7 @@ class Swipeable extends Component {
 
     let contentCenterChildIndex = Math.floor(this.childXCenterPosList.length / 2);
 
+    // Center by props index or select the "most" centered child.
     if (!isNaN(this.props.currentIndex)) {
       contentCenterChildIndex = this.props.currentIndex;
     }
@@ -45,7 +46,7 @@ class Swipeable extends Component {
   }
 
   componentWillReceiveProps(nProps) {
-    // Index state was changed in a component higher up.
+    // Index state was changed by a component containing the `Swipeable`.
     if (this.props.currentIndex !== nProps.currentIndex) {
       this.positionViewByChildIndex(nProps.currentIndex);
     }
@@ -57,6 +58,7 @@ class Swipeable extends Component {
     const currentIndex = this.props.currentIndex,
       childLimitLength = this.childXCenterPosList.length - 1;
 
+    // Prevent external index management to step out of bounds.
     if (currentIndex < 0) {
       this.props.onChange(0);
     } else if (currentIndex > childLimitLength) {
@@ -67,13 +69,10 @@ class Swipeable extends Component {
       return;
     }
 
+    // Finally trigger `onChange` cb if it's defined.
     if (typeof this.props.onChange === 'function') {
       this.props.onChange(this.state.currentCenteredChildIndex);
     }
-  }
-
-  shouldComponentUpdate(nProp, nState) {
-    return true;
   }
 
   componentWillUnmount() {
@@ -299,12 +298,15 @@ class Swipeable extends Component {
 
     let nextTarget = this.state.direction === Swipeable.LEFT ? ++currentChildIndex : --currentChildIndex;
 
-    if (nextTarget < 0 ) {
+    if (nextTarget < 0) {
       nextTarget = 0;
     } else if (nextTarget === this.childXCenterPosList.length) {
       nextTarget = this.childXCenterPosList.length - 1;
     }
 
+    // If velocity of a swipe is greater thatn the specified flick sensitivity
+    // and the drag ditance is lesser or equal to the first child with.
+    // A flick gesture has been initiated.
     if (
       this.getDragVelocity() > this.props.flickSensitivity &&
       Math.abs(distance) <= this.content.childNodes[0].offsetWidth

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -36,8 +36,10 @@ class Swipeable extends Component {
       contentCenterChildIndex = this.props.currentIndex;
     }
 
+    const contentPos = this.viewportCenter - this.childXCenterPosList[contentCenterChildIndex].clientXCenter;
+
     this.setState({
-      contentPos: this.viewportCenter - this.childXCenterPosList[contentCenterChildIndex].clientXCenter,
+      contentPos,
       currentCenteredChildIndex: contentCenterChildIndex
     });
   }
@@ -51,6 +53,15 @@ class Swipeable extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     this.updateViewMetrics();
+
+    const currentIndex = this.props.currentIndex,
+      childLimitLength = this.childXCenterPosList.length - 1;
+
+    if (currentIndex < 0) {
+      this.props.onChange(0);
+    } else if (currentIndex > childLimitLength) {
+      this.props.onChange(childLimitLength);
+    }
 
     if (prevState.currentCenteredChildIndex === this.state.currentCenteredChildIndex) {
       return;
@@ -188,7 +199,6 @@ class Swipeable extends Component {
     let newCordinates = {};
 
     if (e.type === 'touchstart') {
-
         newCordinates = {
           clientX: e.touches[0].clientX,
           oldClientX: e.touches[0].clientX,

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -36,7 +36,7 @@ class SwipeableComponent extends Component {
   }
 
   onChange(index) {
-    // Container state if swiper is updated internally by a drag and keep indexes in sync.
+    // Update container state if swipeable is updated internally by a drag.
     this.setState({ currentIndex: index });
   }
 

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -14,10 +14,44 @@ function renderTestItems() {
   });
 }
 
-const SwipeableComponent = () => (
-  <Swipeable>
-    { renderTestItems() }
-  </Swipeable>
-);
+class SwipeableComponent extends Component {
+  constructor(props) {
+    super(props);
+
+    this.setSwipeNode = this.setSwipeNode.bind(this);
+    this.forward = this.step.bind(this, true);
+    this.backward = this.step.bind(this, false);
+  }
+
+  step(forwards) {
+    let currentIndex = this.swiper.state.currentCenteredChildIndex;
+
+    forwards === true ?
+      this.swiper.positionViewByChildIndex(++currentIndex):
+      this.swiper.positionViewByChildIndex(--currentIndex);
+  }
+
+  setSwipeNode(node) {
+    this.swiper = node;
+  }
+
+  render() {
+    return (
+      <div>
+        <Swipeable ref={ this.setSwipeNode }>
+          { renderTestItems() }
+        </Swipeable>
+
+        <div onClick={ this.forward }>
+          { `Go to forward` }
+        </div>
+
+        <div onClick={ this.backward }>
+          { `Go to backward` }
+        </div>
+      </div>
+    );
+  }
+}
 
 export default SwipeableComponent;

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -41,6 +41,7 @@ class SwipeableComponent extends Component {
 
   onChange(index) {
     // Container state if swiper is updated internally by a drag and keep indexes in sync.
+    console.log(index);
     this.setState({ currentIndex: index });
   }
 

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -18,27 +18,39 @@ class SwipeableComponent extends Component {
   constructor(props) {
     super(props);
 
-    this.setSwipeNode = this.setSwipeNode.bind(this);
+    this.state = { currentIndex: 0 };
+
+    this.onChange = this.onChange.bind(this);
     this.forward = this.step.bind(this, true);
     this.backward = this.step.bind(this, false);
   }
 
-  step(forwards) {
-    let currentIndex = this.swiper.state.currentCenteredChildIndex;
+  step(forward) {
+    let currentIndex = this.state.currentIndex;
 
-    forwards === true ?
-      this.swiper.positionViewByChildIndex(++currentIndex):
-      this.swiper.positionViewByChildIndex(--currentIndex);
+    if (forward) {
+      this.setState({ currentIndex: ++this.state.currentIndex });
+    } else {
+      this.setState({ currentIndex: --this.state.currentIndex });
+    }
   }
 
   setSwipeNode(node) {
     this.swiper = node;
   }
 
+  onChange(index) {
+    // Container state if swiper is updated internally by a drag and keep indexes in sync.
+    this.setState({ currentIndex: index });
+  }
+
   render() {
     return (
       <div>
-        <Swipeable ref={ this.setSwipeNode }>
+        <Swipeable
+          onChange={ this.onChange }
+          currentIndex={ this.state.currentIndex }
+        >
           { renderTestItems() }
         </Swipeable>
 

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -35,13 +35,8 @@ class SwipeableComponent extends Component {
     }
   }
 
-  setSwipeNode(node) {
-    this.swiper = node;
-  }
-
   onChange(index) {
     // Container state if swiper is updated internally by a drag and keep indexes in sync.
-    console.log(index);
     this.setState({ currentIndex: index });
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,19 +2,19 @@ var webpack = require('webpack');
 
 const webpackConfig = {
   module: {},
-  entry: {
-    'swipeable-app': './test/index'
-  },
-
   devtool: 'source-map',
-
-  output: {
-    path: './assets',
-    filename: '[name].js'
-  },
-
+  modulesDirectories: ['node_modules', 'src'],
   target: 'web'
 }
+
+webpackConfig.entry =  {
+  'swipeable-app': './test/index'
+},
+
+webpackConfig.output = {
+  path: './assets',
+  filename: '[name].js'
+},
 
 webpackConfig.module.loaders = [{
   test: /\.(js)$/,
@@ -28,7 +28,15 @@ webpackConfig.module.loaders = [{
 webpackConfig.devServer = {
   historyApiFallback: true,
   contentBase: './assets',
-  port: 8001
+  port: 8001,
+  stats: {
+    chunks: false,
+    chunkModules: false,
+    colors: true,
+    quiet: false,
+    noInfo: false,
+    lazy: false,
+  }
 }
 
 module.exports = webpackConfig;


### PR DESCRIPTION
`onChange` is triggered on internal swipe actions and passes the new index as the single parameter.

``` js
function cb(index) {
  ...
}

<Swipeable onChange={ cb }>
  ...
</Swipeable>
```

It's now also possible to control the index position externally through prop `currentIndex`. If this property is used I advise to use the `onChange` callback to ensure that the containers state index is updated as a internal swipe occurs.

``` js
<Swipeable
  onChange={ this.onChange }
  currentIndex={ this.state.currentIndex }
>
  ...
</Swipeable>
```
