### PR TITLE
[RDY] Make swipeable more dynamic

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,7 +1,6 @@
 .child {
   width: 100%;
   height: 100px;
-  display: inline-block;
 }
 
 .child:nth-child(1) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,5 +1,6 @@
 .child {
   width: 100%;
+  height: 100px;
   display: inline-block;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,28 +1,24 @@
 .child {
-  width: 20rem;
-  height: 10rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: white;
+  width: 100%;
+  display: inline-block;
 }
 
-.child-1 {
-  background: red;
+.child:nth-child(1) {
+  background-color: red;
 }
 
-.child-2 {
-  background: blue;
+.child:nth-child(2) {
+  background-color: blue;
 }
 
-.child-3 {
-  background: green;
+.child:nth-child(3) {
+  background-color: green;
 }
 
-.child-4 {
-  background: purple;
+.child:nth-child(4) {
+  background-color: purple;
 }
 
-.child-5 {
-  background: yellow;
+.child:nth-child(5) {
+  background-color: black;
 }

--- a/lib/style.js
+++ b/lib/style.js
@@ -3,18 +3,12 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _reactPrefixer = require('react-prefixer');
-
-var _reactPrefixer2 = _interopRequireDefault(_reactPrefixer);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-exports.default = (0, _reactPrefixer2.default)({
+var styles = {
   swipeable: {
-    display: 'flex',
-    width: '100%',
-    overflow: 'hidden'
+    height: 'auto',
+    width: 'auto',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap'
   },
 
   animate: {
@@ -22,9 +16,8 @@ exports.default = (0, _reactPrefixer2.default)({
   },
 
   swipeableContent: {
-    willChange: 'transform, transition',
-    display: 'flex',
-    flexDirection: 'row',
-    flexShrink: '0'
+    willChange: 'transform, transition'
   }
-});
+};
+
+exports.default = styles;

--- a/lib/swipeable.js
+++ b/lib/swipeable.js
@@ -12,9 +12,9 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactPrefixer = require('react-prefixer');
+var _static = require('inline-style-prefixer/static');
 
-var _reactPrefixer2 = _interopRequireDefault(_reactPrefixer);
+var _static2 = _interopRequireDefault(_static);
 
 var _style = require('./style');
 
@@ -116,6 +116,18 @@ var Swipeable = function (_Component) {
     }
 
     /**
+     * Calculate total width of child nodes and return negated value as right limit
+     */
+
+  }, {
+    key: 'calculateRightLimit',
+    value: function calculateRightLimit() {
+      var childNodes = this.content.children;
+      var totalWidth = childNodes[0].offsetWidth * childNodes.length;;
+      return -Math.abs(totalWidth);
+    }
+
+    /**
      * Update components properties to keep track of the DOM elements metrics used when swiping.
      */
 
@@ -123,17 +135,14 @@ var Swipeable = function (_Component) {
     key: 'updateViewMetrics',
     value: function updateViewMetrics() {
       this.leftLimit = 0;
+      this.rightLimit = this.calculateRightLimit();
       this.viewportWidth = this.viewport.offsetWidth;
       this.viewportCenter = this.viewportWidth / 2;
-      this.rightLimit = this.viewportWidth - this.content.offsetWidth;
 
-      // If last child is lesser than the viewport, allow it to be dragged a bit further.
-      if (this.content.childNodes[0].offsetWidth < this.viewportWidth) {
-        var slack = this.viewportWidth / 2;
+      var slack = this.viewportWidth / 2;
 
-        this.leftLimit = slack;
-        this.rightLimit = this.viewportWidth - this.content.offsetWidth - slack;
-      }
+      this.leftLimit = slack;
+      this.rightLimit = this.rightLimit + slack;
 
       this.determineChildrensMainAxisCenter();
     }
@@ -386,12 +395,12 @@ var Swipeable = function (_Component) {
       var translateStr = 'translate3d(' + this.state.contentPos + 'px, 0, 0)',
           style = {
         transform: translateStr
-      },
-          prefixStyles = (0, _reactPrefixer2.default)(style);
+      };
+      prefixedStyles = (0, _static2.default)(style);
 
-      for (var prefix in prefixStyles) {
-        if (prefixStyles.hasOwnProperty(prefix)) {
-          this.content.style[prefix] = prefixStyles[prefix];
+      for (var prefix in prefixedStyles) {
+        if (prefixedStyles.hasOwnProperty(prefix)) {
+          this.content.style[prefix] = prefixedStyles[prefix];
         }
       }
 

--- a/lib/swipeable.js
+++ b/lib/swipeable.js
@@ -65,15 +65,49 @@ var Swipeable = function (_Component) {
 
       var contentCenterChildIndex = Math.floor(this.childXCenterPosList.length / 2);
 
+      // Center by props index or select the "most" centered child.
+      if (!isNaN(this.props.currentIndex)) {
+        contentCenterChildIndex = this.props.currentIndex;
+      }
+
+      var contentPos = this.viewportCenter - this.childXCenterPosList[contentCenterChildIndex].clientXCenter;
+
       this.setState({
-        contentPos: this.viewportCenter - this.childXCenterPosList[contentCenterChildIndex].clientXCenter,
+        contentPos: contentPos,
         currentCenteredChildIndex: contentCenterChildIndex
       });
     }
   }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(nProps) {
+      // Index state was changed by a component containing the `Swipeable`.
+      if (this.props.currentIndex !== nProps.currentIndex) {
+        this.positionViewByChildIndex(nProps.currentIndex);
+      }
+    }
+  }, {
     key: 'componentDidUpdate',
-    value: function componentDidUpdate() {
+    value: function componentDidUpdate(prevProps, prevState) {
       this.updateViewMetrics();
+
+      var currentIndex = this.props.currentIndex,
+          childLimitLength = this.childXCenterPosList.length - 1;
+
+      // Prevent external index management to step out of bounds.
+      if (currentIndex < 0) {
+        this.props.onChange(0);
+      } else if (currentIndex > childLimitLength) {
+        this.props.onChange(childLimitLength);
+      }
+
+      if (prevState.currentCenteredChildIndex === this.state.currentCenteredChildIndex) {
+        return;
+      }
+
+      // Finally trigger `onChange` cb if it's defined.
+      if (typeof this.props.onChange === 'function') {
+        this.props.onChange(this.state.currentCenteredChildIndex);
+      }
     }
   }, {
     key: 'componentWillUnmount',
@@ -123,9 +157,9 @@ var Swipeable = function (_Component) {
 
       // Determine center x cordinate of each child.
       for (var i = 0, childStartXCoordinate = 0; i < childCount; i++) {
-        var clientXCenter = undefined,
-            childCenter = undefined,
-            currentChild = undefined;
+        var clientXCenter = void 0,
+            childCenter = void 0,
+            currentChild = void 0;
 
         currentChild = this.content.childNodes[i];
         childCenter = currentChild.offsetWidth / 2;
@@ -187,11 +221,12 @@ var Swipeable = function (_Component) {
   }, {
     key: 'getDragVelocity',
     value: function getDragVelocity() {
-      var _state = this.state;
-      var clientStartX = _state.clientStartX;
-      var clientEndX = _state.clientEndX;
-      var timeFromStart = _state.timeFromStart;
-      var timeTraveled = Date.now() - timeFromStart;
+      var _state = this.state,
+          clientStartX = _state.clientStartX,
+          clientEndX = _state.clientEndX,
+          timeFromStart = _state.timeFromStart,
+          timeTraveled = Date.now() - timeFromStart;
+
 
       return Math.abs(clientEndX - clientStartX) / timeTraveled;
     }
@@ -202,17 +237,17 @@ var Swipeable = function (_Component) {
 
   }, {
     key: 'positionViewByChildIndex',
-    value: function positionViewByChildIndex(index) {
-      // Limit index bounds.
-      if (index < 0) {
-        index = 0;
-      } else if (index === this.childXCenterPosList.length) {
-        index = this.childXCenterPosList.length - 1;
+    value: function positionViewByChildIndex(targetIndex) {
+      // Limit targetIndex bounds.
+      if (targetIndex < 0) {
+        targetIndex = 0;
+      } else if (targetIndex === this.childXCenterPosList.length) {
+        targetIndex = this.childXCenterPosList.length - 1;
       }
 
       this.setState({
-        contentPos: this.viewportCenter - this.childXCenterPosList[index].clientXCenter,
-        currentCenteredChildIndex: index
+        contentPos: this.viewportCenter - this.childXCenterPosList[targetIndex].clientXCenter,
+        currentCenteredChildIndex: targetIndex
       });
     }
   }, {
@@ -221,7 +256,6 @@ var Swipeable = function (_Component) {
       var newCordinates = {};
 
       if (e.type === 'touchstart') {
-
         newCordinates = {
           clientX: e.touches[0].clientX,
           oldClientX: e.touches[0].clientX,
@@ -249,17 +283,17 @@ var Swipeable = function (_Component) {
         return;
       }
 
-      var nextState = undefined,
-          clientX = undefined,
-          clientY = undefined;
+      var nextState = void 0,
+          clientX = void 0,
+          clientY = void 0;
 
       if (e.type === 'touchmove') {
         clientX = e.touches[0].clientX;
         clientY = e.touches[0].clientY;
 
-        var _state2 = this.state;
-        var oldClientY = _state2.oldClientY;
-        var oldClientX = _state2.oldClientX;
+        var _state2 = this.state,
+            oldClientY = _state2.oldClientY,
+            oldClientX = _state2.oldClientX;
 
         // Compute inclination and decide if x-drag should be ignored.
 
@@ -324,8 +358,19 @@ var Swipeable = function (_Component) {
         return;
       }
 
+      var nextTarget = this.state.direction === Swipeable.LEFT ? ++currentChildIndex : --currentChildIndex;
+
+      if (nextTarget < 0) {
+        nextTarget = 0;
+      } else if (nextTarget === this.childXCenterPosList.length) {
+        nextTarget = this.childXCenterPosList.length - 1;
+      }
+
+      // If velocity of a swipe is greater thatn the specified flick sensitivity
+      // and the drag ditance is lesser or equal to the first child with.
+      // A flick gesture has been initiated.
       if (this.getDragVelocity() > this.props.flickSensitivity && Math.abs(distance) <= this.content.childNodes[0].offsetWidth) {
-        this.state.direction === Swipeable.LEFT ? this.positionViewByChildIndex(++currentChildIndex) : this.positionViewByChildIndex(--currentChildIndex);
+        this.positionViewByChildIndex(nextTarget);
       } else {
         this.repositionToClosestChildCenter();
       }
@@ -412,7 +457,7 @@ var Swipeable = function (_Component) {
 Swipeable.LEFT = 'LEFT';
 Swipeable.RIGHT = 'RIGHT';
 Swipeable.propTypes = {
-  children: _react.PropTypes.arrayOf(_react.PropTypes.element),
+  children: _react.PropTypes.arrayOf(_react.PropTypes.element).isRequired,
   className: _react.PropTypes.string,
   flickSensitivity: _react.PropTypes.number,
   slopeLimit: _react.PropTypes.number

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react": "^15.3.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
-    "react-prefixer": "^1.1.4",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.15.1"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git@github.com:JoelRoxell/r-swipeable.git"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
+    "babel-cli": "^6.18.0",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r-swipeable",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Swipeable react wrapper for any number of child elements. (web)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/style.js
+++ b/src/style.js
@@ -1,6 +1,4 @@
-import autoprefixer from 'react-prefixer';
-
-export default autoprefixer({
+const styles = {
   swipeable: {
     height: 'auto',
     width: 'auto',
@@ -15,4 +13,6 @@ export default autoprefixer({
   swipeableContent: {
      willChange: 'transform, transition'
   }
-});
+};
+
+export default styles;

--- a/src/style.js
+++ b/src/style.js
@@ -2,9 +2,10 @@ import autoprefixer from 'react-prefixer';
 
 export default autoprefixer({
   swipeable: {
-    display: 'flex',
-    width: '100%',
-    overflow: 'hidden'
+    height: 'auto',
+    width: 'auto',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap'
   },
 
   animate: {
@@ -12,9 +13,6 @@ export default autoprefixer({
   },
 
   swipeableContent: {
-     willChange: 'transform, transition',
-     display: 'flex',
-     flexDirection: 'row',
-     flexShrink: '0'
+     willChange: 'transform, transition'
   }
 });

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import autoprefixer from 'react-prefixer';
+import prefixAll from 'inline-style-prefixer/static';
 import styles from './style';
 
 class Swipeable extends Component {
@@ -332,11 +332,11 @@ class Swipeable extends Component {
       style = {
         transform: translateStr
       },
-      prefixStyles = autoprefixer(style);
+      prefixedStyles = prefixAll(style);
 
-    for (let prefix in prefixStyles) {
-      if (prefixStyles.hasOwnProperty(prefix)) {
-        this.content.style[prefix] = prefixStyles[prefix];
+    for (let prefix in prefixedStyles) {
+      if (prefixedStyles.hasOwnProperty(prefix)) {
+        this.content.style[prefix] = prefixedStyles[prefix];
       }
     }
 

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -80,6 +80,15 @@ class Swipeable extends Component {
   }
 
   /**
+   * Calculate total width of child nodes and return negated value as right limit
+   */
+  calculateRightLimit() {
+    const childNodes = this.content.children;
+    const totalWidth = childNodes[0].offsetWidth * childNodes.length;;
+    return -Math.abs(totalWidth);
+  }
+
+  /**
    * Update components properties to keep track of the DOM elements metrics used when swiping.
    */
   updateViewMetrics() {

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -45,7 +45,6 @@ class Swipeable extends Component {
     });
 
     this.applyDisplayRuleToChildNodes();
-
   }
 
   componentWillReceiveProps(nProps) {
@@ -87,8 +86,9 @@ class Swipeable extends Component {
    */
   calculateRightLimit() {
     const childNodes = this.content.children;
-    const totalWidth = childNodes[0].offsetWidth * childNodes.length;;
-    return -Math.abs(totalWidth);
+    const totalWidth = childNodes[0].offsetWidth * childNodes.length;
+
+    return -totalWidth;
   }
 
   /**
@@ -358,6 +358,11 @@ class Swipeable extends Component {
     this.content = node;
   }
 
+  /**
+   * This adds 'display: inline-block' to all childnodes to spare users the
+   * trouble of doing it manually and, also, prevent them from setting it to
+   * anything else
+   */
   applyDisplayRuleToChildNodes() {
     for (let i = 0; i < this.content.childNodes.length; i++) {
       this.content.childNodes[i].style.display = 'inline-block';

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -93,17 +93,14 @@ class Swipeable extends Component {
    */
   updateViewMetrics() {
     this.leftLimit = 0;
+    this.rightLimit = this.calculateRightLimit();
     this.viewportWidth = this.viewport.offsetWidth;
     this.viewportCenter = this.viewportWidth / 2;
-    this.rightLimit = this.viewportWidth - this.content.offsetWidth;
 
-    // If last child is lesser than the viewport, allow it to be dragged a bit further.
-    if (this.content.childNodes[0].offsetWidth < this.viewportWidth) {
-      const slack = this.viewportWidth / 2;
+    const slack = this.viewportWidth / 2;
 
-      this.leftLimit = slack;
-      this.rightLimit = (this.viewportWidth - this.content.offsetWidth) - slack;
-    }
+    this.leftLimit = slack;
+    this.rightLimit = this.rightLimit + slack;
 
     this.determineChildrensMainAxisCenter();
   }

--- a/src/swipeable.js
+++ b/src/swipeable.js
@@ -43,6 +43,9 @@ class Swipeable extends Component {
       contentPos,
       currentCenteredChildIndex: contentCenterChildIndex
     });
+
+    this.applyDisplayRuleToChildNodes();
+
   }
 
   componentWillReceiveProps(nProps) {
@@ -353,6 +356,12 @@ class Swipeable extends Component {
 
   setContentNode(node) {
     this.content = node;
+  }
+
+  applyDisplayRuleToChildNodes() {
+    for (let i = 0; i < this.content.childNodes.length; i++) {
+      this.content.childNodes[i].style.display = 'inline-block';
+    }
   }
 
   setStyle() {

--- a/test/swipeable-app.js
+++ b/test/swipeable-app.js
@@ -5,7 +5,7 @@ function renderTestItems() {
   return [1, 2, 3, 4, 5].map(i => {
     return (
       <div
-        className={`child child-${i}`}
+        className={ 'child' }
         key={ i }
       >
         { i }


### PR DESCRIPTION
Updates babel dependencies, (now uses babel-cli instead of babel).

Add support for setting any width of child nodes, with css, and having the swipeable adapt.

Replaces module 'react-prefixer' with 'inline-style-prefixer' which has support for server side rendering.

Tested, and working, in:
- Chrome
- Firefox
- Safari
- Safari for iOS
